### PR TITLE
Add AVIF image format support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ assets = [
 
 [dependencies]
 webp = { version = "*", path = "./webp" }
-#ravif = { version = "0.11.8" }
-#rgb = "0.8.44"
+ravif = { version = "0.11.8" }
+rgb = "0.8.44"
 
 tokio = { version = "1", features = ["full"] }
 poem-openapi = { version = "5.0.2", features = ["redoc", "uuid", "url", "swagger-ui"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,7 +52,7 @@ pub async fn init(config_file: &Path) -> Result<()> {
 
 fn validate(cfg: &RuntimeConfig) -> Result<()> {
     for (name, cfg) in cfg.buckets.iter() {
-        if !cfg.formats.png && !cfg.formats.jpeg && !cfg.formats.gif && !cfg.formats.webp {
+        if !cfg.formats.png && !cfg.formats.jpeg && !cfg.formats.gif && !cfg.formats.webp && !cfg.formats.avif {
             return Err(anyhow!(
                 "Bucket {} is invalid: At least one encoding format must be enabled.",
                 name
@@ -212,6 +212,9 @@ pub enum ImageKind {
 
     /// The GIF encoding format.
     Gif,
+
+    /// The AVIF encoding format.
+    Avif,
 }
 
 #[allow(clippy::from_over_into)]
@@ -222,6 +225,9 @@ impl Into<image::ImageFormat> for ImageKind {
             Self::Jpeg => image::ImageFormat::Jpeg,
             Self::Gif => image::ImageFormat::Gif,
             Self::Webp => image::ImageFormat::WebP,
+            Self::Avif => image::ImageFormat::Unsupported(
+                "AVIF not directly supported by image crate version, handle in encoder",
+            ),
         }
     }
 }
@@ -233,10 +239,12 @@ impl ImageKind {
             "image/jpeg" => Some(Self::Jpeg),
             "image/gif" => Some(Self::Gif),
             "image/webp" => Some(Self::Webp),
+            "image/avif" => Some(Self::Avif),
             "png" => Some(Self::Png),
             "jpeg" => Some(Self::Jpeg),
             "gif" => Some(Self::Gif),
             "webp" => Some(Self::Webp),
+            "avif" => Some(Self::Avif),
             _ => None,
         }
     }
@@ -247,6 +255,7 @@ impl ImageKind {
             image::ImageFormat::Jpeg => Some(Self::Jpeg),
             image::ImageFormat::Gif => Some(Self::Gif),
             image::ImageFormat::WebP => Some(Self::Webp),
+            image::ImageFormat::Avif => Some(Self::Avif),
             _ => None,
         }
     }
@@ -261,11 +270,12 @@ impl ImageKind {
             ImageKind::Jpeg => "jpeg",
             ImageKind::Webp => "webp",
             ImageKind::Gif => "gif",
+            ImageKind::Avif => "avif",
         }
     }
 
     pub fn variants() -> &'static [Self] {
-        &[Self::Png, Self::Jpeg, Self::Gif, Self::Webp]
+        &[Self::Png, Self::Jpeg, Self::Gif, Self::Webp, Self::Avif]
     }
 }
 
@@ -305,6 +315,18 @@ pub struct ImageFormats {
     /// performance behavour.
     pub webp_config: WebpConfig,
 
+    #[serde(default)]
+    /// Enable AVIF re-encoding.
+    ///
+    /// Defaults to `false`.
+    pub avif: bool,
+
+    #[serde(default)]
+    /// The (optional) AVIF encoder config.
+    ///
+    /// This is used for fine-tuning the AVIF encoder.
+    pub avif_config: AvifFormatConfig,
+
     #[serde(default = "default_original_format")]
     /// The format to encode and store the original image as.
     ///
@@ -320,6 +342,7 @@ impl ImageFormats {
             ImageKind::Jpeg => self.jpeg,
             ImageKind::Webp => self.webp,
             ImageKind::Gif => self.gif,
+            ImageKind::Avif => self.avif,
         }
     }
 
@@ -332,6 +355,10 @@ impl ImageFormats {
             return ImageKind::Jpeg;
         }
 
+        if self.avif {
+            return ImageKind::Avif;
+        }
+
         if self.webp {
             return ImageKind::Webp;
         }
@@ -342,6 +369,21 @@ impl ImageFormats {
 
         panic!("Invalid configuration, expected at least one enabled format.")
     }
+}
+
+#[derive(Copy, Clone, Debug, Default, Deserialize)]
+pub struct AvifFormatConfig {
+    /// Quality for RGB channels (0-100, where 100 is best).
+    /// ravif default: 80.0
+    pub quality: Option<f32>,
+
+    /// Quality for the alpha channel (0-100, where 100 is best).
+    /// ravif default: 80.0 (but we'll default to 100.0 for potentially lossless alpha if not set)
+    pub alpha_quality: Option<f32>,
+
+    /// Encoding speed (0-10, where 0 is slowest/best compression, 10 is fastest).
+    /// ravif default: 4
+    pub speed: Option<u8>,
 }
 
 #[derive(Copy, Clone, Debug, Default, Deserialize)]

--- a/src/pipelines/jit.rs
+++ b/src/pipelines/jit.rs
@@ -38,6 +38,7 @@ impl Pipeline for JustInTimePipeline {
         let img = load_from_memory_with_format(&data, kind.into())?;
         let img = processor::encoder::encode_once(
             webp_config,
+            if self.formats.original_image_store_format == ImageKind::Avif { Some(self.formats.avif_config) } else { None },
             self.formats.original_image_store_format,
             img,
             0,
@@ -79,7 +80,13 @@ impl Pipeline for JustInTimePipeline {
             (img, 0)
         };
 
-        let encoded = processor::encoder::encode_once(webp_config, desired_kind, img, sizing_id)?;
+        let avif_cfg_to_pass = if desired_kind == ImageKind::Avif {
+            Some(self.formats.avif_config)
+        } else {
+            None
+        };
+
+        let encoded = processor::encoder::encode_once(webp_config, avif_cfg_to_pass, desired_kind, img, sizing_id)?;
 
         Ok(PipelineResult {
             response: Some(StoreEntry {

--- a/src/pipelines/realtime.rs
+++ b/src/pipelines/realtime.rs
@@ -35,6 +35,7 @@ impl Pipeline for RealtimePipeline {
         let img = load_from_memory_with_format(&data, kind.into())?;
         let img = processor::encoder::encode_once(
             webp_config,
+            if self.formats.original_image_store_format == ImageKind::Avif { Some(self.formats.avif_config) } else { None },
             self.formats.original_image_store_format,
             img,
             0,
@@ -94,7 +95,13 @@ impl Pipeline for RealtimePipeline {
             (img, 0)
         };
 
-        let encoded = processor::encoder::encode_once(webp_config, desired_kind, img, sizing_id)?;
+        let avif_cfg_to_pass = if desired_kind == ImageKind::Avif {
+            Some(self.formats.avif_config)
+        } else {
+            None
+        };
+
+        let encoded = processor::encoder::encode_once(webp_config, avif_cfg_to_pass, desired_kind, img, sizing_id)?;
 
         Ok(PipelineResult {
             response: Some(StoreEntry {

--- a/src/processor/encoder.rs
+++ b/src/processor/encoder.rs
@@ -1,6 +1,7 @@
-use crate::config::{ImageFormats, ImageKind};
+use crate::config::{AvifFormatConfig, ImageFormats, ImageKind};
 use bytes::Bytes;
 use image::{DynamicImage, ImageFormat};
+use ravif::{Config as AvifConfig, Encoder as AvifEncoder, RGBA8};
 use std::io::Cursor;
 use std::sync::Arc;
 
@@ -26,12 +27,16 @@ pub fn encode_following_config(
 
     let (tx, rx) = crossbeam::channel::bounded(4);
 
+    // let avif_config_from_cfg = cfg.avif_config; // This is now available
+
     for variant in ImageKind::variants() {
         if cfg.is_enabled(*variant) {
             let tx_local = tx.clone();
             let local = original_image.clone();
+            // Pass the actual avif_config from the bucket's format settings
+            let avif_config_to_pass = if *variant == ImageKind::Avif { Some(cfg.avif_config) } else { None };
             rayon::spawn(move || {
-                let result = encode_to(webp_config, &local, (*variant).into());
+                let result = encode_to(webp_config, avif_config_to_pass, &local, *variant);
                 tx_local
                     .send(result.map(|v| EncodedImage {
                         kind: *variant,
@@ -60,6 +65,7 @@ pub fn encode_following_config(
 
 pub fn encode_once(
     webp_cfg: webp::WebPConfig,
+    avif_cfg_opt: Option<AvifFormatConfig>, // Added
     to: ImageKind,
     img: DynamicImage,
     sizing_id: u32,
@@ -67,7 +73,7 @@ pub fn encode_once(
     let (tx, rx) = crossbeam::channel::bounded(4);
 
     rayon::spawn(move || {
-        let result = encode_to(webp_cfg, &img, to.into());
+        let result = encode_to(webp_cfg, avif_cfg_opt, &img, to); // Modified call
         tx.send(result.map(|v| EncodedImage {
             kind: to,
             buff: v,
@@ -82,25 +88,52 @@ pub fn encode_once(
 #[inline]
 pub fn encode_to(
     webp_cfg: webp::WebPConfig,
+    avif_cfg_opt: Option<AvifFormatConfig>, // Added
     img: &DynamicImage,
-    format: ImageFormat,
+    image_kind: ImageKind, // Changed from format: ImageFormat
 ) -> anyhow::Result<Bytes> {
-    if let ImageFormat::WebP = format {
+    if image_kind == ImageKind::Webp {
         let webp_image = webp::Encoder::from_image(webp_cfg, img);
         let encoded = webp_image.encode();
+        Ok(Bytes::from(encoded?.to_vec()))
+    } else if image_kind == ImageKind::Avif {
+        let rgba_img = img.to_rgba8();
+        let width = rgba_img.width();
+        let height = rgba_img.height();
 
-        return Ok(Bytes::from(encoded?.to_vec()));
-    }
+        // Convert image::Rgba<u8> pixels to ravif::RGBA8 pixels
+        // Rgba<u8>.0 is [u8; 4], so p.0 gives [u8; 4]
+        // RGBA8::new takes r, g, b, a as u8
+        let pixels: Vec<RGBA8> = rgba_img
+            .pixels()
+            .map(|p| RGBA8::new(p[0], p[1], p[2], p[3]))
+            .collect();
 
-    let mut buff = Cursor::new(Vec::new());
+        let ravif_config = avif_cfg_opt.map_or_else(
+            AvifConfig::default, // Use ravif's default if no specific config is provided
+            |c| AvifConfig {
+                quality: c.quality.unwrap_or(80.0), 
+                alpha_quality: c.alpha_quality.unwrap_or(100.0), // 100 for lossless alpha is common
+                speed: c.speed.unwrap_or(6), // ravif speed: 0 (best quality) to 10 (fastest)
+                ..Default::default() 
+            },
+        );
 
-    // Convert the image to RGB if it's RGBA and we're encoding to JPEG
-    let img_to_encode = if format == ImageFormat::Jpeg && img.color() == image::ColorType::Rgba8 {
-        DynamicImage::ImageRgb8(img.to_rgb8())
+        let avif_data = AvifEncoder::new(ravif_config).encode_rgba(width, height, &pixels)?;
+        Ok(Bytes::from(avif_data))
     } else {
-        img.clone()
-    };
+        let mut buff = Cursor::new(Vec::new());
+        // Convert our ImageKind to the image crate's ImageFormat for other formats
+        let format_for_image_crate: ImageFormat = image_kind.into();
 
-    img_to_encode.write_to(&mut buff, format)?;
-    Ok(Bytes::from(buff.into_inner()))
+        // Convert the image to RGB if it's RGBA and we're encoding to JPEG
+        let img_to_encode = if format_for_image_crate == ImageFormat::Jpeg && img.color() == image::ColorType::Rgba8 {
+            DynamicImage::ImageRgb8(img.to_rgb8())
+        } else {
+            img.clone()
+        };
+
+        img_to_encode.write_to(&mut buff, format_for_image_crate)?;
+        Ok(Bytes::from(buff.into_inner()))
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -68,6 +68,26 @@ async fn validate_image_content(
     Ok(())
 }
 
+async fn validate_avif_content(res: TestResponse) -> anyhow::Result<()> {
+    res.assert_content_type(&"image/avif".to_string());
+    let body = res.0.into_body().into_bytes().await?;
+    assert!(!body.is_empty(), "AVIF body should not be empty");
+
+    // Check for AVIF magic bytes: `ftypavif`
+    // The first 12 bytes of an AVIF file usually are `....ftypavif` where `....` is the size.
+    if body.len() >= 12 {
+        assert_eq!(&body[4..12], b"ftypavif", "AVIF magic bytes not found");
+    } else {
+        // Might be a very small or truncated AVIF, or not an AVIF.
+        // For this basic check, we'll just warn if it's too short for magic bytes.
+        // A more robust checker would use a proper AVIF parser.
+        // For now, the content type check and non-empty body are the primary assertions.
+        println!("Warning: AVIF body too short for magic byte check (len: {})", body.len());
+    }
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_basic_aot_upload_retrieval_without_guessing() -> anyhow::Result<()> {
     let app = setup_environment(AOT_CONFIG).await?;
@@ -223,6 +243,129 @@ async fn test_basic_realtime_upload_retrieval() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_jit_upload_avif_retrieval() -> anyhow::Result<()> {
+    let app = setup_environment(JIT_CONFIG).await?;
+
+    let res = app
+        .post("/v1/user-profiles")
+        .body(TEST_IMAGE)
+        .content_type("application/octet-stream".to_string())
+        .typed_header(headers::ContentLength(TEST_IMAGE.len() as u64))
+        .query("format".to_string(), &"jpeg".to_string()) // Upload as JPEG
+        .send()
+        .await;
+
+    res.assert_status(StatusCode::OK);
+    let info = res.json().await;
+    let file_id = info.value().object().get("image_id").string();
+
+    // JIT mode with avif: true in config, default_serving_format: jpeg
+    // Request AVIF explicitly
+    let res = app
+        .get(format!("/v1/user-profiles/{}", file_id))
+        .query("format", &"avif".to_string())
+        .send()
+        .await;
+
+    res.assert_status(StatusCode::OK);
+    validate_avif_content(res).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jit_upload_custom_avif_retrieval() -> anyhow::Result<()> {
+    let app = setup_environment(JIT_CONFIG).await?;
+
+    let res = app
+        .post("/v1/user-profiles")
+        .body(TEST_IMAGE)
+        .content_type("application/octet-stream".to_string())
+        .typed_header(headers::ContentLength(TEST_IMAGE.len() as u64))
+        .query("format".to_string(), &"jpeg".to_string()) // Upload as JPEG
+        .send()
+        .await;
+    
+    res.assert_status(StatusCode::OK);
+    let info = res.json().await;
+    let file_id = info.value().object().get("image_id").string();
+
+    // Request AVIF explicitly
+    let res = app
+        .get(format!("/v1/user-profiles/{}", file_id))
+        .query("format", &"avif".to_string())
+        .send()
+        .await;
+
+    res.assert_status(StatusCode::OK);
+    validate_avif_content(res).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_aot_upload_avif_retrieval() -> anyhow::Result<()> {
+    let app = setup_environment(AOT_CONFIG).await?;
+
+    let res = app
+        .post("/v1/user-profiles")
+        .body(TEST_IMAGE)
+        .content_type("application/octet-stream".to_string())
+        .typed_header(headers::ContentLength(TEST_IMAGE.len() as u64))
+        .query("format".to_string(), &"jpeg".to_string()) // Upload as JPEG
+        .send()
+        .await;
+
+    res.assert_status(StatusCode::OK);
+    let info = res.json().await;
+    let file_id = info.value().object().get("image_id").string();
+    
+    // AOT mode with avif: true in config.
+    // default_serving_format is webp, so request avif explicitly
+    let res = app
+        .get(format!("/v1/user-profiles/{}", file_id))
+        .query("format", &"avif".to_string())
+        .send()
+        .await;
+    
+    res.assert_status(StatusCode::OK);
+    validate_avif_content(res).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_realtime_upload_avif_retrieval() -> anyhow::Result<()> {
+    let app = setup_environment(REALTIME_CONFIG).await?;
+
+    let res = app
+        .post("/v1/user-profiles")
+        .body(TEST_IMAGE)
+        .content_type("application/octet-stream".to_string())
+        .typed_header(headers::ContentLength(TEST_IMAGE.len() as u64))
+        .query("format".to_string(), &"jpeg".to_string()) // Upload as JPEG
+        .send()
+        .await;
+
+    res.assert_status(StatusCode::OK);
+    let info = res.json().await;
+    let file_id = info.value().object().get("image_id").string();
+
+    // Realtime mode, request AVIF explicitly
+    let res = app
+        .get(format!("/v1/user-profiles/{}", file_id))
+        .query("format", &"avif".to_string())
+        .send()
+        .await;
+
+    res.assert_status(StatusCode::OK);
+    validate_avif_content(res).await?;
+
+    Ok(())
+}
+
 
 #[tokio::test]
 async fn test_realtime_resizing() -> anyhow::Result<()> {

--- a/tests/configs/aot-mode.yaml
+++ b/tests/configs/aot-mode.yaml
@@ -14,9 +14,13 @@ buckets:
       jpeg: true  # Enable JPEG encoding.
       webp: true  # Enable WebP encoding.
       gif: false  # Disable GIF encoding.
+      avif: true  # Enable AVIF encoding
 
       webp_config:
         quality: 80       # Set lossy quality to 80%
+      avif_config:
+        quality: 70.0
+        speed: 4
         method: 4         # Opt on the side of performance slightly more than quality.
         threading: true   # Enable multi-threaded encoding.
 

--- a/tests/configs/jit-mode.yaml
+++ b/tests/configs/jit-mode.yaml
@@ -14,9 +14,13 @@ buckets:
       jpeg: true  # Enable JPEG encoding.
       webp: false  # Disable WebP encoding.
       gif: false  # Disable GIF encoding.
+      avif: true # Enable AVIF encoding
 
       webp_config:
         quality: 80       # Set lossy quality to 80%
+      avif_config:
+        quality: 75.0
+        speed: 3
         method: 4         # Opt on the side of performance slightly more than quality.
         threading: true   # Enable multi-threaded encoding.
 

--- a/tests/configs/realtime-mode.yaml
+++ b/tests/configs/realtime-mode.yaml
@@ -14,11 +14,16 @@ buckets:
       jpeg: true  # Enable JPEG encoding.
       webp: true  # Enable WebP encoding.
       gif: false  # Disable GIF encoding.
+      avif: true  # Enable AVIF encoding
 
       original_image_store_format: jpeg
 
       webp_config:
         quality: 80       # Set lossy quality to 80%
+      avif_config:
+        quality: 65.0
+        speed: 5
+        alpha_quality: 80.0
         method: 4         # Opt on the side of performance slightly more than quality.
         threading: true   # Enable multi-threaded encoding.
 


### PR DESCRIPTION
This change introduces support for the AVIF image format.

Key changes:
- Added `ravif` and `rgb` dependencies for AVIF encoding.
- Updated `ImageKind` enum in `src/config.rs` to include `Avif`, along with related helper functions.
- Implemented AVIF encoding logic in `src/processor/encoder.rs` using the `ravif` crate.
  - The `encode_to` function now handles `ImageKind::Avif`.
  - `encode_following_config` and `encode_once` were updated to manage AVIF configuration.
- Added `AvifFormatConfig` to `src/config.rs` to allow you to configure AVIF quality and speed settings in the application's YAML/JSON configuration.
- Updated `ImageFormats` in `src/config.rs` to include AVIF enablement and specific configuration.
- Added integration tests in `src/tests.rs` for AVIF encoding in JIT, AOT, and Realtime modes.
  - Test configuration files (`*.yaml`) were updated to enable AVIF and provide default AVIF encoder settings.
  - A new validation function, `validate_avif_content`, was added to check AVIF content type and magic bytes.
- Ensured that AVIF-specific configuration is correctly passed through the encoding pipeline, including updates to `jit.rs` and `realtime.rs`.