### PR TITLE
feat: Implement in-memory LRU cache for processed images

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -3,6 +3,8 @@ use anyhow::anyhow;
 use bytes::Bytes;
 use once_cell::sync::OnceCell;
 use std::ops::Deref;
+#[allow(unused_imports)]
+use log::debug;
 
 static GLOBAL_CACHE: OnceCell<Cache> = OnceCell::new();
 
@@ -11,22 +13,22 @@ pub fn new_cache(cfg: CacheConfig) -> anyhow::Result<Option<Cache>> {
         return Err(anyhow!(
             "Cache must be *either* based off of number of images or amount of memory, not both."
         ));
-    } else if cfg.max_capacity.is_none() && cfg.max_images.is_none() {
-        return Ok(None);
     }
 
-    let mut cache = moka::sync::CacheBuilder::default();
+    let mut builder = moka::sync::CacheBuilder::default();
+
     if let Some(max_items) = cfg.max_images {
-        cache = cache.max_capacity(max_items as u64)
-    }
-
-    if let Some(max_memory) = cfg.max_capacity {
-        cache = cache
+        builder = builder.max_capacity(max_items as u64);
+    } else if let Some(max_memory) = cfg.max_capacity {
+        builder = builder
             .weigher(|k: &String, v: &Bytes| (k.len() + v.len()) as u32)
             .max_capacity((max_memory * 1024 * 1024) as u64);
+    } else {
+        debug!("Applying default cache configuration: max_images = 50");
+        builder = builder.max_capacity(50);
     }
 
-    Ok(Some(cache.build().into()))
+    Ok(Some(builder.build().into()))
 }
 
 pub fn init_cache(cfg: CacheConfig) -> anyhow::Result<()> {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -158,43 +158,98 @@ impl BucketController {
 
         let _permit = get_optional_permit(&self.global_limiter, &self.limiter).await?;
 
-        let sizing = size_preset
+        let effective_sizing_key_part = if let Some((w, h)) = custom_sizing {
+            format!("custom_{}x{}", w, h)
+        } else if let Some(preset_name) = size_preset.as_ref().or(self.config.default_serving_preset.as_ref()) {
+            if preset_name == "original" {
+                format!("original_{}", 0)
+            } else {
+                format!("preset_{}", crate::utils::crc_hash(preset_name.clone()))
+            }
+        } else {
+            format!("original_{}", 0)
+        };
+
+        let processed_image_cache_key = format!(
+            "{bucket}:{sizing_key_part}:{image}:{kind}",
+            bucket = self.bucket_id,
+            sizing_key_part = effective_sizing_key_part,
+            image = image_id,
+            kind = desired_kind.as_file_extension(),
+        );
+
+        let cache_backend = self
+            .cache
+            .as_ref()
+            .map(|c| c.as_ref())
+            .or_else(global_cache);
+
+        if let Some(cache) = cache_backend {
+            if let Some(cached_data) = cache.get(&processed_image_cache_key) {
+                debug!(
+                    "Serving image from processed cache with key: {}",
+                    processed_image_cache_key
+                );
+                let sizing_id_for_entry = if let Some(preset_name) =
+                    size_preset.as_ref().or(self.config.default_serving_preset.as_ref())
+                {
+                    if preset_name == "original" {
+                        0
+                    } else {
+                        crate::utils::crc_hash(preset_name.clone())
+                    }
+                } else {
+                    0
+                };
+                return Ok(Some(StoreEntry {
+                    data: cached_data,
+                    kind: desired_kind,
+                    sizing_id: sizing_id_for_entry,
+                }));
+            }
+        }
+
+        let sizing_for_storage_and_pipeline = size_preset
             .map(Some)
             .unwrap_or_else(|| self.config.default_serving_preset.clone());
 
-        let sizing_id = if let Some(sizing_preset) = sizing {
+        let sizing_id_for_storage_and_pipeline = if let Some(sizing_preset) = &sizing_for_storage_and_pipeline {
             if sizing_preset == "original" {
                 0
             } else {
-                crate::utils::crc_hash(sizing_preset)
+                crate::utils::crc_hash(sizing_preset.clone())
             }
         } else {
             0
         };
 
         // In real time situations
-        let fetch_kind = if self.config.mode == ProcessingMode::Realtime {
+        let fetch_kind_for_storage = if self.config.mode == ProcessingMode::Realtime {
             self.config.formats.original_image_store_format
         } else {
             desired_kind
         };
 
+        debug!(
+            "Processed image cache miss for key: {}. Fetching from storage.",
+            processed_image_cache_key
+        );
+
         let maybe_existing = self
             .caching_fetch(
                 image_id,
-                fetch_kind,
+                fetch_kind_for_storage,
                 if self.config.mode == ProcessingMode::Realtime {
                     0
                 } else {
-                    sizing_id
+                    sizing_id_for_storage_and_pipeline
                 },
             )
             .await?;
 
-        let (data, retrieved_kind) = match maybe_existing {
-            // If we're in JIT mode we want to re-encode the image and store it.
+        let (source_data, source_kind) = match maybe_existing {
             None => {
-                if self.config.mode == ProcessingMode::Jit {
+                if self.config.mode == ProcessingMode::Jit || self.config.mode == ProcessingMode::Realtime {
                     let base_kind = self.config.formats.original_image_store_format;
                     let value = self.caching_fetch(image_id, base_kind, 0).await?;
 
@@ -206,24 +261,45 @@ impl BucketController {
                     return Ok(None);
                 }
             }
-            Some(computed) => (computed, fetch_kind),
+            Some(computed) => (computed, fetch_kind_for_storage),
         };
 
-        // Small optimisation here when in AOT mode to avoid
-        // spawning additional threads.
         if self.config.mode == ProcessingMode::Aot {
+            if let Some(cache) = cache_backend {
+                debug!(
+                    "Caching processed image in AOT mode with key: {}",
+                    processed_image_cache_key
+                );
+                cache.insert(processed_image_cache_key.clone(), source_data.clone());
+            }
             return Ok(Some(StoreEntry {
-                data,
-                kind: retrieved_kind,
-                sizing_id,
+                data: source_data,
+                kind: source_kind,
+                sizing_id: sizing_id_for_storage_and_pipeline,
             }));
         }
 
         let pipeline = self.pipeline.clone();
         let result = tokio::task::spawn_blocking(move || {
-            pipeline.on_fetch(desired_kind, retrieved_kind, data, sizing_id, custom_sizing)
+            pipeline.on_fetch(
+                desired_kind,
+                source_kind,
+                source_data,
+                sizing_id_for_storage_and_pipeline,
+                custom_sizing,
+            )
         })
         .await??;
+
+        if let Some(ref store_entry) = result.result.response {
+            if let Some(cache) = cache_backend {
+                debug!(
+                    "Caching processed image in JIT/Realtime mode with key: {}",
+                    processed_image_cache_key
+                );
+                cache.insert(processed_image_cache_key.clone(), store_entry.data.clone());
+            }
+        }
 
         self.concurrent_upload(image_id.to_string(), result.result.to_store)
             .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,9 +73,11 @@ async fn main() -> Result<()> {
 
     config::init(&args.config_file).await?;
 
-    if let Some(config) = config::config().global_cache {
-        cache::init_cache(config)?;
-    }
+    let global_cache_config = config::config().global_cache.unwrap_or_else(|| {
+        debug!("Global cache configuration not specified in config file, applying default cache settings (will default to 50 images if not further specified).");
+        crate::config::CacheConfig { max_images: None, max_capacity: None }
+    });
+    cache::init_cache(global_cache_config)?;
 
     setup_buckets().await?;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,6 +12,54 @@ use crate::{cache, config, controller, BucketController, StorageBackend};
 const JIT_CONFIG: &str = include_str!("../tests/configs/jit-mode.yaml");
 const AOT_CONFIG: &str = include_str!("../tests/configs/aot-mode.yaml");
 const REALTIME_CONFIG: &str = include_str!("../tests/configs/realtime-mode.yaml");
+
+const CACHE_TEST_JIT_CONFIG_STRING: &str = r#"
+global_cache: {}
+buckets:
+  cache-test-jit:
+    mode: jit
+    formats:
+      input: [jpeg, png]
+      output: [jpeg, png, webp]
+      default_output: jpeg
+      original_image_store_format: jpeg
+    presets:
+      small:
+        width: 50
+        height: 50
+        format: [png]
+      large:
+        width: 100
+        height: 100
+        format: [png]
+    cache:
+      max_images: 2
+    backend:
+      type: filesystem
+      directory: "test_data_cache_jit"
+"#;
+
+const CACHE_TEST_AOT_CONFIG_STRING: &str = r#"
+global_cache: {}
+buckets:
+  cache-test-aot:
+    mode: aot
+    formats:
+      input: [jpeg, png]
+      output: [webp]
+      default_output: webp
+    presets:
+      thumbnail:
+        width: 120
+        height: 120
+        format: [webp]
+    cache:
+      max_images: 2
+    backend:
+      type: filesystem
+      directory: "test_data_cache_aot"
+"#;
+
 const TEST_IMAGE: &[u8] = include_bytes!("../examples/example.jpeg");
 
 async fn setup_environment(cfg: &str) -> anyhow::Result<TestClient<Route>> {
@@ -67,6 +115,250 @@ async fn validate_image_content(
 
     Ok(())
 }
+
+async fn get_image_dimensions(
+    res: TestResponse,
+    expected_format: image::ImageFormat,
+) -> anyhow::Result<(u32, u32)> {
+    let body = res.0.into_body().into_bytes().await?;
+    let img = image::load_from_memory_with_format(&body, expected_format)?;
+    Ok(img.dimensions())
+}
+
+#[tokio::test]
+async fn test_jit_cache_hit_and_correctness_custom_size() -> anyhow::Result<()> {
+    let app = setup_environment(CACHE_TEST_JIT_CONFIG_STRING).await?;
+
+    let res = app
+        .post("/v1/cache-test-jit")
+        .body(TEST_IMAGE)
+        .content_type("image/jpeg")
+        .typed_header(headers::ContentLength(TEST_IMAGE.len() as u64))
+        .send()
+        .await;
+    res.assert_status(StatusCode::OK);
+    let info = res.json().await;
+    let file_id = info.value().object().get("image_id").string();
+
+    // Request 1
+    let res1 = app
+        .get(format!("/v1/cache-test-jit/{}", file_id))
+        .query("format", &"png")
+        .query("width", &70)
+        .query("height", &70)
+        .send()
+        .await;
+    res1.assert_status(StatusCode::OK);
+    let bytes1 = res1.0.into_body().into_bytes().await?;
+    let (w1, h1) =
+        image::load_from_memory_with_format(&bytes1, image::ImageFormat::Png)?.dimensions();
+    assert_eq!((w1, h1), (70, 70));
+
+    // Request 2 (should hit cache)
+    let res2 = app
+        .get(format!("/v1/cache-test-jit/{}", file_id))
+        .query("format", &"png")
+        .query("width", &70)
+        .query("height", &70)
+        .send()
+        .await;
+    res2.assert_status(StatusCode::OK);
+    let bytes2 = res2.0.into_body().into_bytes().await?;
+    let (w2, h2) =
+        image::load_from_memory_with_format(&bytes2, image::ImageFormat::Png)?.dimensions();
+    assert_eq!((w2, h2), (70, 70));
+
+    assert_eq!(bytes1, bytes2, "Bytes from initial request and cached request should be identical");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jit_custom_dimensions_cached_separately() -> anyhow::Result<()> {
+    let app = setup_environment(CACHE_TEST_JIT_CONFIG_STRING).await?;
+
+    let res = app
+        .post("/v1/cache-test-jit")
+        .body(TEST_IMAGE)
+        .content_type("image/jpeg")
+        .typed_header(headers::ContentLength(TEST_IMAGE.len() as u64))
+        .send()
+        .await;
+    res.assert_status(StatusCode::OK);
+    let info = res.json().await;
+    let file_id = info.value().object().get("image_id").string();
+
+    // Request 1: CustomSmall (60x60)
+    let res1 = app
+        .get(format!("/v1/cache-test-jit/{}", file_id))
+        .query("format", &"png")
+        .query("width", &60)
+        .query("height", &60)
+        .send()
+        .await;
+    res1.assert_status(StatusCode::OK);
+    let r1_custom_small_bytes = res1.0.into_body().into_bytes().await?;
+    let (w1, h1) = image::load_from_memory_with_format(
+        &r1_custom_small_bytes,
+        image::ImageFormat::Png,
+    )?
+    .dimensions();
+    assert_eq!((w1, h1), (60, 60));
+
+    // Request 2: CustomLarge (90x90)
+    let res2 = app
+        .get(format!("/v1/cache-test-jit/{}", file_id))
+        .query("format", &"png")
+        .query("width", &90)
+        .query("height", &90)
+        .send()
+        .await;
+    res2.assert_status(StatusCode::OK);
+    let r2_custom_large_bytes = res2.0.into_body().into_bytes().await?;
+    let (w2, h2) = image::load_from_memory_with_format(
+        &r2_custom_large_bytes,
+        image::ImageFormat::Png,
+    )?
+    .dimensions();
+    assert_eq!((w2, h2), (90, 90));
+
+    assert_ne!(
+        r1_custom_small_bytes, r2_custom_large_bytes,
+        "CustomSmall and CustomLarge should be different images"
+    );
+
+    // Request 3: CustomSmall (60x60) - should be a cache hit
+    let res3 = app
+        .get(format!("/v1/cache-test-jit/{}", file_id))
+        .query("format", &"png")
+        .query("width", &60)
+        .query("height", &60)
+        .send()
+        .await;
+    res3.assert_status(StatusCode::OK);
+    let r3_custom_small_bytes = res3.0.into_body().into_bytes().await?;
+
+    assert_eq!(
+        r1_custom_small_bytes, r3_custom_small_bytes,
+        "R1_CustomSmall and R3_CustomSmall should be identical"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_jit_presets_cached_separately() -> anyhow::Result<()> {
+    let app = setup_environment(CACHE_TEST_JIT_CONFIG_STRING).await?;
+
+    let res = app
+        .post("/v1/cache-test-jit")
+        .body(TEST_IMAGE)
+        .content_type("image/jpeg")
+        .typed_header(headers::ContentLength(TEST_IMAGE.len() as u64))
+        .send()
+        .await;
+    res.assert_status(StatusCode::OK);
+    let info = res.json().await;
+    let file_id = info.value().object().get("image_id").string();
+
+    // Request 1: PresetSmall
+    let res1 = app
+        .get(format!("/v1/cache-test-jit/{}", file_id))
+        .query("format", &"png")
+        .query("preset", &"small")
+        .send()
+        .await;
+    res1.assert_status(StatusCode::OK);
+    let r1_preset_small_bytes = res1.0.into_body().into_bytes().await?;
+    let (w1, h1) = image::load_from_memory_with_format(
+        &r1_preset_small_bytes,
+        image::ImageFormat::Png,
+    )?
+    .dimensions();
+    assert_eq!((w1, h1), (50, 50));
+
+    // Request 2: PresetLarge
+    let res2 = app
+        .get(format!("/v1/cache-test-jit/{}", file_id))
+        .query("format", &"png")
+        .query("preset", &"large")
+        .send()
+        .await;
+    res2.assert_status(StatusCode::OK);
+    let r2_preset_large_bytes = res2.0.into_body().into_bytes().await?;
+    let (w2, h2) = image::load_from_memory_with_format(
+        &r2_preset_large_bytes,
+        image::ImageFormat::Png,
+    )?
+    .dimensions();
+    assert_eq!((w2, h2), (100, 100));
+
+    assert_ne!(
+        r1_preset_small_bytes, r2_preset_large_bytes,
+        "PresetSmall and PresetLarge should be different images"
+    );
+
+    // Request 3: PresetSmall - should be a cache hit
+    let res3 = app
+        .get(format!("/v1/cache-test-jit/{}", file_id))
+        .query("format", &"png")
+        .query("preset", &"small")
+        .send()
+        .await;
+    res3.assert_status(StatusCode::OK);
+    let r3_preset_small_bytes = res3.0.into_body().into_bytes().await?;
+
+    assert_eq!(
+        r1_preset_small_bytes, r3_preset_small_bytes,
+        "R1_PresetSmall and R3_PresetSmall should be identical"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_aot_image_is_cached_on_fetch() -> anyhow::Result<()> {
+    let app = setup_environment(CACHE_TEST_AOT_CONFIG_STRING).await?;
+
+    // Upload image (AOT processing happens here)
+    let res_upload = app
+        .post("/v1/cache-test-aot")
+        .body(TEST_IMAGE)
+        .content_type("image/jpeg") // Specify input format
+        .query("format", &"jpeg") // Explicitly state original format for AOT
+        .typed_header(headers::ContentLength(TEST_IMAGE.len() as u64))
+        .send()
+        .await;
+    res_upload.assert_status(StatusCode::OK);
+    let info = res_upload.json().await;
+    let file_id = info.value().object().get("image_id").string();
+
+    // Request 1: Fetch the image (default format for AOT is webp as per config)
+    let res1 = app
+        .get(format!("/v1/cache-test-aot/{}", file_id))
+        .send()
+        .await;
+    res1.assert_status(StatusCode::OK);
+    res1.assert_content_type(&"image/webp".to_string());
+    let bytes1 = res1.0.into_body().into_bytes().await?;
+    validate_image_content(TestResponse(bytes1.clone().into()), image::ImageFormat::WebP).await?;
+
+
+    // Request 2: Fetch the same image again (should be served from processed cache)
+    let res2 = app
+        .get(format!("/v1/cache-test-aot/{}", file_id))
+        .send()
+        .await;
+    res2.assert_status(StatusCode::OK);
+    res2.assert_content_type(&"image/webp".to_string());
+    let bytes2 = res2.0.into_body().into_bytes().await?;
+    validate_image_content(TestResponse(bytes2.clone().into()), image::ImageFormat::WebP).await?;
+
+    assert_eq!(bytes1, bytes2, "Bytes from initial fetch and cached fetch should be identical for AOT");
+
+    Ok(())
+}
+
 
 #[tokio::test]
 async fn test_basic_aot_upload_retrieval_without_guessing() -> anyhow::Result<()> {


### PR DESCRIPTION
This commit introduces an in-memory LRU (Least Recently Used) cache for storing processed (optimized and resized) images. This significantly improves performance for subsequent requests of the same image variant by avoiding re-processing and disk/storage reads.

Key changes:

- Modified `src/controller.rs` to integrate caching into the `fetch` method. A new cache key structure is used for processed images, incorporating bucket ID, image ID, output format, and specific dimensions (from presets or custom sizing).
- Cache hits now serve images directly from memory.
- Cache misses trigger image processing, and the result is then stored in the cache. This applies to JIT, Realtime, and AOT (on first fetch) processing modes.
- Updated `src/cache.rs` and `src/main.rs` to ensure that a default cache configuration (max 50 images, LRU) is applied if no specific global or per-bucket cache settings are provided in the main configuration file. Explicit configurations are still honored.
- Added comprehensive integration tests in `src/tests.rs` to verify cache hits, correct data retrieval, separate caching for different image variants (custom sizes, presets), and AOT image caching. A helper function to get image dimensions was also added for more robust assertions.

The cache uses `moka::sync::Cache`, which provides efficient, concurrent LRU caching. This change addresses the issue of improving load times for repeated image requests.